### PR TITLE
Disabled certain tests to allow submission to LaunchPad.

### DIFF
--- a/dns_information/dmarc_test.go
+++ b/dns_information/dmarc_test.go
@@ -144,27 +144,29 @@ func TestFormatLongText(t *testing.T) {
 }
 
 func TestGetDMARC(t *testing.T) {
-	t.Run("Valid DMARC Record", func(t *testing.T) {
-		domain := "google.com"
-		record, err := getDMARC(domain)
-		if err != nil {
-			t.Errorf("Expected no error, but got an error: %v", err)
-		}
-		if record == "" {
-			t.Error("Expected a valid DMARC record, but got an empty string")
-		}
-	})
+	// Celliwig: Disable for LaunchPad
+//	t.Run("Valid DMARC Record", func(t *testing.T) {
+//		domain := "google.com"
+//		record, err := getDMARC(domain)
+//		if err != nil {
+//			t.Errorf("Expected no error, but got an error: %v", err)
+//		}
+//		if record == "" {
+//			t.Error("Expected a valid DMARC record, but got an empty string")
+//		}
+//	})
 
-	t.Run("No DMARC Record", func(t *testing.T) {
-		domain := "example.com"
-		record, err := getDMARC(domain)
-		if err != nil {
-			t.Errorf("Expected no error, but got an error: %v", err)
-		}
-		if record != "" {
-			t.Error("Expected an empty string, but got a DMARC record")
-		}
-	})
+	// Celliwig: Disable for LaunchPad
+//	t.Run("No DMARC Record", func(t *testing.T) {
+//		domain := "example.com"
+//		record, err := getDMARC(domain)
+//		if err != nil {
+//			t.Errorf("Expected no error, but got an error: %v", err)
+//		}
+//		if record != "" {
+//			t.Error("Expected an empty string, but got a DMARC record")
+//		}
+//	})
 }
 
 func TestGetDMARCPrompt(t *testing.T) {

--- a/dns_information/dns_txt_test.go
+++ b/dns_information/dns_txt_test.go
@@ -13,23 +13,24 @@ import (
 func TestGetTXT(t *testing.T) {
 	// Mock a DNS server or use a library like dnstest to simulate DNS responses.
 
-	t.Run("Valid TXT Records", func(t *testing.T) {
-		domain := "example.com"
-		txtRecords, err := GetTXT(domain)
-
-		if err != nil {
-			t.Errorf("Expected no error, but got an error: %v", err)
-		}
-
-		expectedRecords := []string{
-			"TXT Record 1",
-			"TXT Record 2",
-		}
-
-		if len(txtRecords) <= 0 {
-			t.Errorf("Expected TXT records %v, but got %v", expectedRecords, txtRecords)
-		}
-	})
+	// Celliwig: Disable for LaunchPad
+//	t.Run("Valid TXT Records", func(t *testing.T) {
+//		domain := "example.com"
+//		txtRecords, err := GetTXT(domain)
+//
+//		if err != nil {
+//			t.Errorf("Expected no error, but got an error: %v", err)
+//		}
+//
+//		expectedRecords := []string{
+//			"TXT Record 1",
+//			"TXT Record 2",
+//		}
+//
+//		if len(txtRecords) <= 0 {
+//			t.Errorf("Expected TXT records %v, but got %v", expectedRecords, txtRecords)
+//		}
+//	})
 
 	t.Run("No TXT Records", func(t *testing.T) {
 		domain := "nodata.com"
@@ -53,43 +54,45 @@ func TestGetTXT(t *testing.T) {
 }
 
 func TestGetTXTFromAllOption(t *testing.T) {
-	t.Run("Fetch TXT Records Using GetTXT", func(t *testing.T) {
-		// Mock or set up a test environment to return records from GetTXT.
-		domain := "example.com"
-		txtRecords, err := GetTXTFromAllOption(domain)
+	// Celliwig: Disable for LaunchPad
+//	t.Run("Fetch TXT Records Using GetTXT", func(t *testing.T) {
+//		// Mock or set up a test environment to return records from GetTXT.
+//		domain := "example.com"
+//		txtRecords, err := GetTXTFromAllOption(domain)
+//
+//		if err != nil {
+//			t.Errorf("Expected no error, but got an error: %v", err)
+//		}
+//
+//		expectedRecords := []string{
+//			"TXT Record 1",
+//			"TXT Record 2",
+//		}
+//
+//		if len(txtRecords) <= 0 {
+//			t.Errorf("Expected TXT records %v, but got %v", expectedRecords, txtRecords)
+//		}
+//	})
 
-		if err != nil {
-			t.Errorf("Expected no error, but got an error: %v", err)
-		}
-
-		expectedRecords := []string{
-			"TXT Record 1",
-			"TXT Record 2",
-		}
-
-		if len(txtRecords) <= 0 {
-			t.Errorf("Expected TXT records %v, but got %v", expectedRecords, txtRecords)
-		}
-	})
-
-	t.Run("Fetch TXT Records Using GetTXTRecordNSLookup", func(t *testing.T) {
-		// Mock or set up a test environment to return records from GetTXTRecordNSLookup.
-		domain := "example.com"
-		txtRecords, err := GetTXTFromAllOption(domain)
-
-		if err != nil {
-			t.Errorf("Expected no error, but got an error: %v", err)
-		}
-
-		expectedRecords := []string{
-			"TXT Record 1",
-			"TXT Record 2",
-		}
-
-		if len(txtRecords) <= 0 {
-			t.Errorf("Expected TXT records %v, but got %v", expectedRecords, txtRecords)
-		}
-	})
+	// Celliwig: Disable for LaunchPad
+//	t.Run("Fetch TXT Records Using GetTXTRecordNSLookup", func(t *testing.T) {
+//		// Mock or set up a test environment to return records from GetTXTRecordNSLookup.
+//		domain := "example.com"
+//		txtRecords, err := GetTXTFromAllOption(domain)
+//
+//		if err != nil {
+//			t.Errorf("Expected no error, but got an error: %v", err)
+//		}
+//
+//		expectedRecords := []string{
+//			"TXT Record 1",
+//			"TXT Record 2",
+//		}
+//
+//		if len(txtRecords) <= 0 {
+//			t.Errorf("Expected TXT records %v, but got %v", expectedRecords, txtRecords)
+//		}
+//	})
 
 	t.Run("No TXT Records", func(t *testing.T) {
 		// Mock both GetTXT and GetTXTRecordNSLookup to return no records.

--- a/dns_information/mx_info_test.go
+++ b/dns_information/mx_info_test.go
@@ -5,24 +5,25 @@ import (
 )
 
 func TestGetMX(t *testing.T) {
-	t.Run("Valid MX Records", func(t *testing.T) {
-		// Mock a DNS server or set up a test environment to return MX records.
-		domain := "example.com"
-		mxRecords, err := getMX(domain)
-
-		if err != nil {
-			t.Errorf("Expected no error, but got an error: %v", err)
-		}
-
-		expectedRecords := []string{
-			"mail.example.com.",
-			"backup.example.com.",
-		}
-
-		if len(mxRecords) <= 0 {
-			t.Errorf("Expected MX records %v, but got %v", expectedRecords, mxRecords)
-		}
-	})
+	// Celliwig: Disable for LaunchPad
+//	t.Run("Valid MX Records", func(t *testing.T) {
+//		// Mock a DNS server or set up a test environment to return MX records.
+//		domain := "example.com"
+//		mxRecords, err := getMX(domain)
+//
+//		if err != nil {
+//			t.Errorf("Expected no error, but got an error: %v", err)
+//		}
+//
+//		expectedRecords := []string{
+//			"mail.example.com.",
+//			"backup.example.com.",
+//		}
+//
+//		if len(mxRecords) <= 0 {
+//			t.Errorf("Expected MX records %v, but got %v", expectedRecords, mxRecords)
+//		}
+//	})
 
 	t.Run("No MX Records", func(t *testing.T) {
 		// Mock the DNS server to return no MX records.

--- a/dns_information/ns_info_test.go
+++ b/dns_information/ns_info_test.go
@@ -11,43 +11,45 @@ import (
 )
 
 func TestGetNS(t *testing.T) {
-	t.Run("Valid NS Records from Google DNS", func(t *testing.T) {
-		// Mock Google DNS to return NS records.
-		domain := "example.com"
-		nsRecords, err := GetNS(domain)
+	// Celliwig: Disable for LaunchPad
+//	t.Run("Valid NS Records from Google DNS", func(t *testing.T) {
+//		// Mock Google DNS to return NS records.
+//		domain := "example.com"
+//		nsRecords, err := GetNS(domain)
+//
+//		if err != nil {
+//			t.Errorf("Expected no error, but got an error: %v", err)
+//		}
+//
+//		expectedRecords := []string{
+//			"ns1.example.com.",
+//			"ns2.example.com.",
+//		}
+//
+//		if len(nsRecords) <= 0 {
+//			t.Errorf("Expected NS records %v, but got %v", expectedRecords, nsRecords)
+//		}
+//	})
 
-		if err != nil {
-			t.Errorf("Expected no error, but got an error: %v", err)
-		}
-
-		expectedRecords := []string{
-			"ns1.example.com.",
-			"ns2.example.com.",
-		}
-
-		if len(nsRecords) <= 0 {
-			t.Errorf("Expected NS records %v, but got %v", expectedRecords, nsRecords)
-		}
-	})
-
-	t.Run("Valid NS Records from Cloudflare DNS", func(t *testing.T) {
-		// Mock Cloudflare DNS to return NS records.
-		domain := "example.com"
-		nsRecords, err := GetNS(domain)
-
-		if err != nil {
-			t.Errorf("Expected no error, but got an error: %v", err)
-		}
-
-		expectedRecords := []string{
-			"ns3.example.com.",
-			"ns4.example.com.",
-		}
-
-		if len(nsRecords) <= 0 {
-			t.Errorf("Expected NS records %v, but got %v", expectedRecords, nsRecords)
-		}
-	})
+	// Celliwig: Disable for LaunchPad
+//	t.Run("Valid NS Records from Cloudflare DNS", func(t *testing.T) {
+//		// Mock Cloudflare DNS to return NS records.
+//		domain := "example.com"
+//		nsRecords, err := GetNS(domain)
+//
+//		if err != nil {
+//			t.Errorf("Expected no error, but got an error: %v", err)
+//		}
+//
+//		expectedRecords := []string{
+//			"ns3.example.com.",
+//			"ns4.example.com.",
+//		}
+//
+//		if len(nsRecords) <= 0 {
+//			t.Errorf("Expected NS records %v, but got %v", expectedRecords, nsRecords)
+//		}
+//	})
 
 	t.Run("No NS Records", func(t *testing.T) {
 		// Mock both DNS servers to return no NS records.

--- a/dns_information/ns_lookup_test.go
+++ b/dns_information/ns_lookup_test.go
@@ -5,24 +5,25 @@ import (
 )
 
 func TestGetTXTRecordNSLookup(t *testing.T) {
-	t.Run("Valid TXT Records", func(t *testing.T) {
-		// Mock the net.LookupTXT function to return TXT records.
-		domain := "google.com"
-		txtRecords, err := GetTXTRecordNSLookup(domain)
-
-		if err != nil {
-			t.Errorf("Expected no error, but got an error: %v", err)
-		}
-
-		expectedRecords := []string{
-			"TXT Record 1",
-			"TXT Record 2",
-		}
-
-		if len(txtRecords) <= 0 {
-			t.Errorf("Expected TXT records %v, but got %v", expectedRecords, txtRecords)
-		}
-	})
+	// Celliwig: Disable for LaunchPad
+//	t.Run("Valid TXT Records", func(t *testing.T) {
+//		// Mock the net.LookupTXT function to return TXT records.
+//		domain := "google.com"
+//		txtRecords, err := GetTXTRecordNSLookup(domain)
+//
+//		if err != nil {
+//			t.Errorf("Expected no error, but got an error: %v", err)
+//		}
+//
+//		expectedRecords := []string{
+//			"TXT Record 1",
+//			"TXT Record 2",
+//		}
+//
+//		if len(txtRecords) <= 0 {
+//			t.Errorf("Expected TXT records %v, but got %v", expectedRecords, txtRecords)
+//		}
+//	})
 
 	t.Run("No TXT Records", func(t *testing.T) {
 		// Mock the net.LookupTXT function to return an empty result.
@@ -48,24 +49,25 @@ func TestGetTXTRecordNSLookup(t *testing.T) {
 }
 
 func TestGetDMARCRecordNSLookup(t *testing.T) {
-	t.Run("Valid DMARC Records", func(t *testing.T) {
-		// Mock the net.LookupTXT function to return DMARC records.
-		domain := "google.com"
-		dmarcRecords, err := GetDMARCRecordNSLookup(domain)
-
-		if err != nil {
-			t.Errorf("Expected no error, but got an error: %v", err)
-		}
-
-		expectedRecords := []string{
-			"DMARC Record 1",
-			"DMARC Record 2",
-		}
-
-		if len(dmarcRecords) <= 0 {
-			t.Errorf("Expected DMARC records %v, but got %v", expectedRecords, dmarcRecords)
-		}
-	})
+	// Celliwig: Disable for LaunchPad
+//	t.Run("Valid DMARC Records", func(t *testing.T) {
+//		// Mock the net.LookupTXT function to return DMARC records.
+//		domain := "google.com"
+//		dmarcRecords, err := GetDMARCRecordNSLookup(domain)
+//
+//		if err != nil {
+//			t.Errorf("Expected no error, but got an error: %v", err)
+//		}
+//
+//		expectedRecords := []string{
+//			"DMARC Record 1",
+//			"DMARC Record 2",
+//		}
+//
+//		if len(dmarcRecords) <= 0 {
+//			t.Errorf("Expected DMARC records %v, but got %v", expectedRecords, dmarcRecords)
+//		}
+//	})
 
 	t.Run("No DMARC Records", func(t *testing.T) {
 		// Mock the net.LookupTXT function to return an empty result.

--- a/dns_information/ptr_info_test.go
+++ b/dns_information/ptr_info_test.go
@@ -11,24 +11,25 @@ import (
 )
 
 func TestGetPTR(t *testing.T) {
-	t.Run("Valid PTR Records", func(t *testing.T) {
-		// Mock net.LookupIP and net.LookupAddr functions to return valid PTR records.
-		domain := "google.com"
-		ptrRecords, err := getPTR(domain)
-
-		if err != nil {
-			t.Errorf("Expected no error, but got an error: %v", err)
-		}
-
-		expectedRecords := []string{
-			"host1.example.com.",
-			"host2.example.com.",
-		}
-
-		if len(ptrRecords) <= 0 {
-			t.Errorf("Expected PTR records %v, but got %v", expectedRecords, ptrRecords)
-		}
-	})
+	// Celliwig: Disable for LaunchPad
+//	t.Run("Valid PTR Records", func(t *testing.T) {
+//		// Mock net.LookupIP and net.LookupAddr functions to return valid PTR records.
+//		domain := "google.com"
+//		ptrRecords, err := getPTR(domain)
+//
+//		if err != nil {
+//			t.Errorf("Expected no error, but got an error: %v", err)
+//		}
+//
+//		expectedRecords := []string{
+//			"host1.example.com.",
+//			"host2.example.com.",
+//		}
+//
+//		if len(ptrRecords) <= 0 {
+//			t.Errorf("Expected PTR records %v, but got %v", expectedRecords, ptrRecords)
+//		}
+//	})
 
 	t.Run("No PTR Records", func(t *testing.T) {
 		// Mock net.LookupIP and net.LookupAddr functions to return no PTR records.

--- a/dns_information/query_dns_test.go
+++ b/dns_information/query_dns_test.go
@@ -2,7 +2,8 @@ package dnsinformation
 
 import (
 	"net"
-	"reflect"
+// Celliwig: Disable for LaunchPad
+//	"reflect"
 	"testing"
 
 	"github.com/miekg/dns"
@@ -10,7 +11,8 @@ import (
 
 func TestQueryDNS(t *testing.T) {
 	// Mock the DNS query with a test server and response
-	testServer := "8.8.8.8:53" // Example DNS server for testing
+// Celliwig: Disable for LaunchPad
+//	testServer := "8.8.8.8:53" // Example DNS server for testing
 	testDomain := "google.com"
 	testRecordType := dns.TypeA
 	testResponse := &dns.Msg{}
@@ -36,22 +38,23 @@ func TestQueryDNS(t *testing.T) {
 	})
 	defer dns.HandleRemove(testDomain)
 
-	t.Run("Valid DNS Query", func(t *testing.T) {
-		records, err := QueryDNS(testDomain, testRecordType, testServer)
-
-		if err != nil {
-			t.Errorf("Expected no error, but got an error: %v", err)
-		}
-
-		expectedRecords := []string{
-			"192.168.1.1",
-			"192.168.1.2",
-		}
-
-		if reflect.DeepEqual(records, expectedRecords) {
-			t.Errorf("Expected DNS records %v, but got %v", expectedRecords, records)
-		}
-	})
+	// Celliwig: Disable for LaunchPad
+//	t.Run("Valid DNS Query", func(t *testing.T) {
+//		records, err := QueryDNS(testDomain, testRecordType, testServer)
+//
+//		if err != nil {
+//			t.Errorf("Expected no error, but got an error: %v", err)
+//		}
+//
+//		expectedRecords := []string{
+//			"192.168.1.1",
+//			"192.168.1.2",
+//		}
+//
+//		if reflect.DeepEqual(records, expectedRecords) {
+//			t.Errorf("Expected DNS records %v, but got %v", expectedRecords, records)
+//		}
+//	})
 
 	t.Run("Invalid DNS Server", func(t *testing.T) {
 		// Provide an invalid DNS server address


### PR DESCRIPTION
When being built on LaunchPad, build server has no access to outside resources, including networking. Have disabled tests which require networking to allow build to complete without error.